### PR TITLE
intellisense inside define

### DIFF
--- a/require.intellisense.js
+++ b/require.intellisense.js
@@ -48,6 +48,12 @@
 
     window.define = function (name, deps, callback) {
         defines.push([name, deps, callback]);
+
+        oldRequire.call(window, deps, callback);
+
+        defines.forEach(function (define) {
+            oldDefine.apply(window, define);
+        });
     }
     
     window.define.amd = {
@@ -78,6 +84,7 @@
     }
 
     // Redirect all of the patched methods back to their originals
+    // so Intellisense will use the previously defined annotations
     intellisense.redirectDefinition(requirejs.load, oldLoad);
     intellisense.redirectDefinition(window.define, oldDefine);
     intellisense.redirectDefinition(window.require, oldRequire);


### PR DESCRIPTION
These changes make intellisense work inside define, at least on my machine with Visual Studio 2012 RTM.  It's possible there are unintended consequences, but so far, so good.  I opted to not use setTimeout and it works fine.  I tried removing setTimeout from window.require and that also seemed to be fine, but I left that out of my commit, leaving that decision up to you since there must be a reason you used it.
