### PR TITLE
My version of require.intellisense.js

### DIFF
--- a/require.intellisense.js
+++ b/require.intellisense.js
@@ -1,19 +1,51 @@
 /// <reference path="require.js" />
+// in this file i have a call to requirejs.config to set baseUrl, paths, shim etc
+// this must be loaded now but, it'll be corrected to absBaseUrl whenever this file needs it
+/// <reference path="requirejs-conf.js" />
+// having added those to references the load order will be 
+//   require.js
+//   require.intellisense.js
+//   requirejs-conf.js
+// so anything that needs overridding from requirejs-conf needs overridding
+// when define/require/requirejs are called (not now).
+
+// ALL defines must have a name e.g. a_name as below, otherwise things will go wrong
+// because visual studio won't tell be where a script was loaded from
+// define('a_name', ['depends'], function(){... return {'hello':'world'});
+
+// if you are debugging intellisense you should put a line like this in all your files
+////intellisense.logMessage('require.intellisense.js');
+
+// absolute url to Scripts, because intellisense doesn't know where it's coming from
+// so relative paths to scripts will all go wrong
+// to set this automatically my current best solution would be to use a T4 template to 
+// generate this file, I've not tried this yet though.
+var absBaseUrl = 'C:/Projects/MyProject/Scripts';
 
 !function (window) {
+    // convert arguments from object to array
+    // usage, argsToArray(arguments)
+    var argsToArray = function (obj) {
+        return Array.prototype.slice.call(obj, 0);
+    };
+
+    // better log method than intellisense.logMessage
+    // and it can be disable easily in one place
+    var ilog = function () {
+        ////intellisense.logMessage(JSON.stringify(argsToArray(arguments, 0)));
+    };
+
     var defines = [],
-        moduleUrls = [],
         oldDefine = window.define,
-        oldRequire = window.require,
-        oldLoad = requirejs.load;
+        tracking = 0;
 
-    var loadEvent = document.createEvent("event");
-    loadEvent.type = "load";
-
-    // Ensure that we're only patching require/define
-    // if RequireJS is the current AMD implementation
-    if (window.require !== window.requirejs)
-        return;
+    var requireDoc = function () {
+        /// <signature>
+        ///     <summary>Defines a callback function that will be triggered after a set of dependency modules have been evaluated</summary>
+        ///     <param name="deps" type="Array" elementType="String"></param>
+        ///     <param name="callback" type="Function"></param>
+        /// </signature>
+    };
 
     intellisense.annotate(window, {
         define: function () {
@@ -32,60 +64,46 @@
             ///     <param name="value" type="Object">The object literal that represents the value of this module</param>
             /// </signature>
         },
-        require: function () {
-            /// <signature>
-            ///     <summary>Defines a callback function that will be triggered after a set of dependency modules have been evaluated</summary>
-            ///     <param name="deps" type="Array" elementType="String"></param>
-            ///     <param name="callback" type="Function"></param>
-            /// </signature>
-        }
+        require: requireDoc,
+        requirejs: requireDoc
     });
 
-    requirejs.load = function (context, moduleName, url) {
-        moduleUrls.push(url);
-        oldLoad.call(requirejs, context, moduleName, url);
-    }
-
+    var fixBaseUrl = function () {
+        requirejs.config({
+            baseUrl: absBaseUrl
+        });
+    };
+    
     window.define = function (name, deps, callback) {
+        fixBaseUrl();
+        
         defines.push([name, deps, callback]);
-
-        oldRequire.call(window, deps, callback);
-
+        var track = '_@t' + (++tracking + 1);
+        ilog('define', track, argsToArray(arguments));
+    
+        if (typeof name !== 'string') {
+            callback = deps;
+            deps = name;
+        }
+    
+        ilog('calling require', track, deps);
+        window.require.call(window, deps, function () {
+            ilog('require callback', track, argsToArray(arguments));
+            callback.apply(this, argsToArray(arguments));
+        });
+    
         defines.forEach(function (define) {
             oldDefine.apply(window, define);
         });
-    }
-    
+    };
+
     window.define.amd = {
         multiversion: true,
         plugins: true,
         jQuery: true
     };
 
-    window.require = function (deps, callback) {
-        setTimeout(function () {
-            // #1. Call the original require
-            oldRequire.call(window, deps, callback);
-            
-            defines.forEach(function (define, index) {
-                oldDefine.apply(window, define);
-
-                var scriptElements = document.getElementsByTagName("script");
-
-                for (var i = 0; i < scriptElements.length; i++) {
-                    var script = scriptElements[i];
-                    if (script.src == moduleUrls[index]) {
-                        loadEvent.currentTarget = script;
-                        requirejs.onScriptLoad(loadEvent);
-                    }
-                }
-            });            
-        }, 0);
-    }
-
     // Redirect all of the patched methods back to their originals
     // so Intellisense will use the previously defined annotations
-    intellisense.redirectDefinition(requirejs.load, oldLoad);
     intellisense.redirectDefinition(window.define, oldDefine);
-    intellisense.redirectDefinition(window.require, oldRequire);
 }(this);


### PR DESCRIPTION
I spent ages researching this and finally came up with this file; achieving intellisense throughout my project. I'm not sure what the `setTimeout` was achieving nor calling `onScriptLoad`, what doesn't happen now I've not called it? 

In the latest version my test examples (below) did not work at all. Perhaps partly because my requirejs.config is complicated and needed loading at the right time, but also the code did not support the `requirejs` global. I guess this project needs some a test project creating. I tried very hard to get Visual Studio to let me know the path of a javascript path it has loaded so that defines can be anonymous but I don't believe it can be done. In my test code `res` and `$` have intellisense the second time I use they continue to work forever. 

```
define('foobar', ['res', 'jquery'], function (res, $) {
    // res and $ have intellisense here
}

requirejs(['res', 'jquery'], function (res, $) {
    // res and $ have intellisense here
}
```
